### PR TITLE
Explicitly use `YAML.unsafe_load` on database config for Ruby 3.1 support with aliases

### DIFF
--- a/post-checkout
+++ b/post-checkout
@@ -194,7 +194,8 @@ if ARGV[2] == '1'
   @dump_folder = "#{@project_root}/.db_branch_dumps"
 
   # Load Rails DB config and grab database name
-  @rails_db_config = YAML.load(ERB.new(File.read("#{@project_root}/config/database.yml")).result)
+  config = ERB.new(File.read("#{@project_root}/config/database.yml")).result
+  @rails_db_config = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(config) : YAML.load(config)
   dev_database_name = @rails_db_config['development']['database']
 
   begin


### PR DESCRIPTION
In Yaml v3.3.1 and below, there's `YAML.load` and `YAML.safe_load`, the
former, which we used, being intended for trusted content, not
user-provided content.

In Yaml v4, `YAML.load` became safe-by-default, meaning aliases were
disabled by default. `YAML.unsafe_load` was added to mirror the old
`YAML.load` behavior for trusted content.

A user of this library should likely be able to trust their own
database.yml file, therefore where available, explicitly load the config
via `YAML.unsafe_load`. This ensures if you use aliases in your config
to extract common keys between environments, it'll still be properly
parsed. Otherwise you'd get a `Psych::BadAlias` error when loading a
config file with aliases, treating it as untrusted user content.